### PR TITLE
corrected a cast from a function to (void *)

### DIFF
--- a/components/device/silabs/si91x/wireless/asynchronous_socket/src/sl_si91x_socket.c
+++ b/components/device/silabs/si91x/wireless/asynchronous_socket/src/sl_si91x_socket.c
@@ -270,7 +270,7 @@ static int sli_si91x_accept_async(int socket, const struct sockaddr *addr, sockl
     }
 
     *client_socket          = client_socket_id;
-    context->user_context   = callback;
+    context->user_context   = &callback;
     context->socket_context = client_socket;
   }
 


### PR DESCRIPTION
Code failed to compile without this change. A more extensive rework may be desired, but this should do it for now.