### PR TITLE
Fixed uninitialized warning

### DIFF
--- a/components/device/silabs/si91x/mcu/drivers/unified_api/src/sl_si91x_usart.c
+++ b/components/device/silabs/si91x/mcu/drivers/unified_api/src/sl_si91x_usart.c
@@ -99,7 +99,7 @@ static usart_peripheral_t get_usart_instance(sl_usart_handle_t usart_handle);
  ******************************************************************************/
 static sl_status_t usart_get_handle(usart_peripheral_t usart_instance, sl_usart_handle_t *usart_handle)
 {
-  sl_status_t status;
+  sl_status_t status = SL_STATUS_FAIL;
   do {
     // Check for USART instance valid
     if (usart_instance >= UARTLAST) {


### PR DESCRIPTION
The "status" variable in usart_get_handle() was not initialized. Thus a random value could be returned if every if-statement was passed. This fixes the warning and removes that possibility, making the code more deterministic.